### PR TITLE
Cross-version settings. Fixed a test that was failing (weirdly, not sure why) in Scala < 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,14 @@
 import Dependencies._
 
+crossScalaVersions := Seq("2.11.8", "2.12.2")
+
 lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(
-      organization := "com.joefkelley",
-      scalaVersion := "2.12.1",
-      version      := "1.0.0"
-    )),
+                  organization := "com.joefkelley",
+                  scalaVersion := "2.12.2",
+                    version      := "1.0.0"
+                )),
     name := "argyle",
     libraryDependencies ++= Seq(
       scalaTest % Test,

--- a/src/test/scala/com/joefkelley/argyle/ArgsSpec.scala
+++ b/src/test/scala/com/joefkelley/argyle/ArgsSpec.scala
@@ -636,7 +636,7 @@ class ArgsSpec extends FlatSpec with Matchers {
   }
   it should "nest with either" in {
     val arg = required[List[Either[Int, Char]]]("--foo")
-    arg.parse("--foo", "1,b,3") should succeedWith(List(Left(1),Right('b'),Left(3)))
+    arg.parse("--foo", "1,b,3") should succeedWith[List[Either[Int, Char]]](List(Left(1),Right('b'),Left(3)))
   }
   
   "Parser" should "fail on unused argument" in {


### PR DESCRIPTION
I found myself wanting to use this library for command line parsing, but stuck with Spark and hence Scala < 2.12. Ended up using scallop, but looks like for my next project I could be using argyle :)